### PR TITLE
Add login route

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,6 +21,7 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="login" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,0 +1,21 @@
+import { StyleSheet } from 'react-native';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function LoginScreen() {
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText type="title">Login</ThemedText>
+      {/* TODO: Add login form here */}
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- add a basic `login` screen
- register the `login` route in the main layout

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858648455488324a71465aac8fd664d