### PR TITLE
Add driver login and delivery tracking

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -40,6 +40,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="deliveries"
+        options={{
+          title: 'Repartos',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="tray.fill" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/deliveries.tsx
+++ b/app/(tabs)/deliveries.tsx
@@ -1,0 +1,85 @@
+import * as ImagePicker from 'expo-image-picker';
+import { useState } from 'react';
+import { View, TextInput, Button, FlatList, Image, StyleSheet } from 'react-native';
+
+import { useDeliveries } from '@/context/DeliveryContext';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function DeliveriesScreen() {
+  const { deliveries, addDelivery, location } = useDeliveries();
+  const [client, setClient] = useState('');
+  const [amount, setAmount] = useState('');
+  const [address, setAddress] = useState('');
+  const [photo, setPhoto] = useState<string | undefined>();
+
+  const pickImage = async () => {
+    const res = await ImagePicker.launchCameraAsync({ quality: 0.5 });
+    if (!res.canceled) setPhoto(res.assets[0].uri);
+  };
+
+  const submit = () => {
+    if (!client || !amount || !address) return;
+    addDelivery({ client, amount: parseFloat(amount), address, photoUri: photo, location });
+    setClient('');
+    setAmount('');
+    setAddress('');
+    setPhoto(undefined);
+  };
+
+  const total = deliveries.reduce((sum, d) => sum + d.amount, 0);
+
+  return (
+    <View style={styles.container}>
+      <ThemedText type="title">Repartos</ThemedText>
+      <TextInput
+        placeholder="Cliente"
+        value={client}
+        onChangeText={setClient}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Monto"
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="numeric"
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Dirección"
+        value={address}
+        onChangeText={setAddress}
+        style={styles.input}
+      />
+      <Button title="Tomar foto" onPress={pickImage} />
+      {photo && <Image source={{ uri: photo }} style={styles.photo} />}
+      <Button title="Agregar" onPress={submit} />
+      <ThemedText type="subtitle">Total: ${total.toFixed(2)}</ThemedText>
+      <FlatList
+        data={deliveries}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={({ item }) => (
+          <View style={styles.item}>
+            <ThemedText>{item.client}</ThemedText>
+            <ThemedText>${item.amount.toFixed(2)}</ThemedText>
+            {item.photoUri && (
+              <Image source={{ uri: item.photoUri }} style={styles.itemPhoto} />
+            )}
+          </View>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20, gap: 8 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    borderRadius: 4,
+  },
+  photo: { width: 200, height: 200, marginVertical: 8 },
+  item: { marginVertical: 4 },
+  itemPhoto: { width: 50, height: 50 },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,26 +4,48 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
+import { AuthProvider, useAuth } from '@/context/AuthContext';
+import { DeliveryProvider, useDeliveries } from '@/context/DeliveryContext';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
-export default function RootLayout() {
+function LayoutNavigator() {
   const colorScheme = useColorScheme();
+  const { user } = useAuth();
+  const { startTracking } = useDeliveries();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
 
   if (!loaded) {
-    // Async font loading only occurs in development.
     return null;
+  }
+
+  if (user) {
+    // Start tracking location when logged in
+    startTracking().catch(() => {});
   }
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        {user ? (
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        ) : (
+          <Stack.Screen name="login" options={{ headerShown: false }} />
+        )}
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />
     </ThemeProvider>
+  );
+}
+
+export default function RootLayout() {
+  return (
+    <AuthProvider>
+      <DeliveryProvider>
+        <LayoutNavigator />
+      </DeliveryProvider>
+    </AuthProvider>
   );
 }

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,0 +1,52 @@
+import { Stack, useRouter } from 'expo-router';
+import { useState } from 'react';
+import { Button, TextInput, View, StyleSheet } from 'react-native';
+
+import { useAuth } from '@/context/AuthContext';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function LoginScreen() {
+  const { login } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: 'Login' }} />
+      <ThemedText type="title">Login</ThemedText>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+        autoCapitalize="none"
+      />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        style={styles.input}
+        secureTextEntry
+      />
+      <Button
+        title="Ingresar"
+        onPress={() => {
+          login(email, password);
+          router.replace('/');
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 20 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4,
+  },
+});

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -16,6 +16,7 @@ type IconSymbolName = keyof typeof MAPPING;
 const MAPPING = {
   'house.fill': 'home',
   'paperplane.fill': 'send',
+  'tray.fill': 'inventory',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
 } as IconMapping;

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface AuthContextType {
+  user: string | null;
+  login: (email: string, password: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<string | null>(null);
+
+  const login = (email: string, password: string) => {
+    // Simple example with no real auth
+    setUser(email);
+  };
+
+  const logout = () => setUser(null);
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be inside AuthProvider');
+  return ctx;
+}

--- a/context/DeliveryContext.tsx
+++ b/context/DeliveryContext.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import * as Location from 'expo-location';
+
+export interface Delivery {
+  id: number;
+  client: string;
+  amount: number;
+  address: string;
+  photoUri?: string;
+  location?: Location.LocationObjectCoords;
+}
+
+interface DeliveryContextType {
+  deliveries: Delivery[];
+  location: Location.LocationObjectCoords | null;
+  addDelivery: (delivery: Omit<Delivery, 'id'>) => void;
+  startTracking: () => Promise<void>;
+}
+
+const DeliveryContext = createContext<DeliveryContextType | undefined>(undefined);
+
+export function DeliveryProvider({ children }: { children: ReactNode }) {
+  const [deliveries, setDeliveries] = useState<Delivery[]>([]);
+  const [location, setLocation] = useState<Location.LocationObjectCoords | null>(null);
+
+  const addDelivery = (delivery: Omit<Delivery, 'id'>) => {
+    setDeliveries((prev) => [...prev, { ...delivery, id: prev.length + 1 }]);
+  };
+
+  const startTracking = async () => {
+    const { status } = await Location.requestForegroundPermissionsAsync();
+    if (status !== 'granted') {
+      console.warn('Permission to access location was denied');
+      return;
+    }
+    await Location.watchPositionAsync(
+      { accuracy: Location.Accuracy.High, distanceInterval: 10 },
+      (loc) => setLocation(loc.coords)
+    );
+  };
+
+  return (
+    <DeliveryContext.Provider value={{ deliveries, location, addDelivery, startTracking }}>
+      {children}
+    </DeliveryContext.Provider>
+  );
+}
+
+export function useDeliveries() {
+  const ctx = useContext(DeliveryContext);
+  if (!ctx) throw new Error('useDeliveries must be inside DeliveryProvider');
+  return ctx;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -18,7 +19,9 @@
         "expo-font": "~13.3.1",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.3.0",
+        "expo-image-picker": "^16.1.4",
         "expo-linking": "~7.1.5",
+        "expo-location": "^18.1.5",
         "expo-router": "~5.1.0",
         "expo-splash-screen": "~0.30.9",
         "expo-status-bar": "~2.2.3",
@@ -2796,6 +2799,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -6327,6 +6342,27 @@
         }
       }
     },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-keep-awake": {
       "version": "14.1.4",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.1.4.tgz",
@@ -6349,6 +6385,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-location": {
+      "version": "18.1.5",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-18.1.5.tgz",
+      "integrity": "sha512-/ugxS4Ort9DbKD0Do6xn4TjeHaA/by5vv0p0PrY5Zbcez1S0AfrQn/4JG/8PLT2imngMwZU9TDKrgxqJQ4RuPQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -7703,6 +7748,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8688,6 +8742,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
@@ -21,7 +22,9 @@
     "expo-font": "~13.3.1",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.3.0",
+    "expo-image-picker": "^16.1.4",
     "expo-linking": "~7.1.5",
+    "expo-location": "^18.1.5",
     "expo-router": "~5.1.0",
     "expo-splash-screen": "~0.30.9",
     "expo-status-bar": "~2.2.3",
@@ -41,9 +44,9 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0"
+    "eslint-config-expo": "~9.2.0",
+    "typescript": "~5.8.3"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- add auth and delivery context
- implement login screen
- add delivery entry screen with photo support
- track location when logged in
- update tab navigator and icon mappings
- install location and image picker dependencies

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68587c16dd548324bc5e43d40eaddb5f